### PR TITLE
increase daily limiter before await

### DIFF
--- a/pokemanpcr/poke_man_pcr.py
+++ b/pokemanpcr/poke_man_pcr.py
@@ -359,6 +359,7 @@ async def poke_back(session: NoticeSession):
                               })
         await session.send(poke)
     else:
+        daily_limiter.increase(guid)
         amount = roll_cards_amount()
         col_num = math.ceil(amount / 2)
         row_num = 2 if amount != 1 else 1
@@ -370,7 +371,6 @@ async def poke_back(session: NoticeSession):
         for card_id in card_counter.keys():
             db.add_card_num(
                 session.ctx['group_id'], session.ctx['user_id'], card_id, card_counter[card_id])
-        daily_limiter.increase(guid)
 
 
 @sv.on_prefix(('献祭', '合成', '融合'))


### PR DESCRIPTION
戳一戳集卡功能，目前用户可以通过一些指令阻塞机器人后，发送多个戳一戳请求，之后机器人会无视3次上限给予集卡回应。

这个修改将增加计数放到 await 之前，避免同时接收到多个戳一戳请求后计数没有即时增加，从而可以无视上限给予回应的问题。